### PR TITLE
0.6.5 - provide test, new operand elements with gas limit

### DIFF
--- a/services/corevm/src/main.rs
+++ b/services/corevm/src/main.rs
@@ -344,6 +344,14 @@ extern "C" fn accumulate(start_address: u64, length: u64) -> (u64, u64) {
         let assign_result = unsafe { assign(1000, jam_address) };
         call_log(2, None, &format!("assign jam: expect CORE {:?}, got {:?} (recorded at key 6)", CORE, assign_result));
         write_result(assign_result, 6);
+
+        let provide_jamhash_result = unsafe { provide(666, jam_hash_address, jam_length) };
+        call_log(2, None, &format!("provide hash(jam): expect WHO, got {:?} (recorded at key 2)", query_jamhash_result));
+        write_result(provide_jamhash_result, 7);
+
+        let provide_jamhash_result2 = unsafe { provide(0, jam_hash_address, jam_length) };
+        call_log(2, None, &format!("provide hash(jam): expect OK, got {:?} (recorded at key 2)", provide_jamhash_result2));
+        write_result(provide_jamhash_result, 8);
     } else if n == 5 {
         let lookup_result = unsafe { lookup(service_index as u64, jam_hash_address, buffer_address, 0, jam_length) };
         call_log(2, None, &format!("lookup hash(jam): expect OK {:?}, got {:?} (recorded at key 1)", OK, lookup_result));
@@ -361,6 +369,10 @@ extern "C" fn accumulate(start_address: u64, length: u64) -> (u64, u64) {
         let bless_who_result = unsafe { bless(overflow_s, 0, 0, jam_hash_address, 0) };
         call_log(2, None, &format!("bless: expect WHO {:?}, got {:?} (recorded at key 6)", WHO, bless_who_result));
         write_result(bless_who_result, 6);
+
+        let provide_jamhash_result = unsafe { provide(0, jam_hash_address, jam_length) };
+        call_log(2, None, &format!("provide hash(jam): expect HUH, got {:?} (recorded at key 8)", provide_jamhash_result2));
+        write_result(provide_jamhash_result, 8);
     } else if n == 6 {
         let solicit_result = unsafe { solicit(jam_hash_address, jam_length) };
         write_result(solicit_result, 1);

--- a/services/utils/src/functions.rs
+++ b/services/utils/src/functions.rs
@@ -116,6 +116,7 @@ pub struct AccumulateArgs {
     pub o_ptr: u64,
     pub o_len: u64,
     pub y: [u8; 32],
+    pub g: u64,
     pub work_result_ptr: u64,
     pub work_result_len: u64,
 }
@@ -211,6 +212,12 @@ pub fn parse_accumulate_args(start_address: u64, length: u64, m: u64) -> Option<
         args.y.copy_from_slice(y_slice);
         current_address += 32;
         remaining_length = remaining_length.saturating_sub(32);
+
+        // 0.6.5 -- add gas limit
+        let g_slice = unsafe { core::slice::from_raw_parts(current_address as *const u8, 8) };
+        u64::from_le_bytes(g_slice[0..8].try_into().unwrap());
+        current_address += 8;
+        remaining_length = remaining_length.saturating_sub(8);
 
         let accumulation_slice = unsafe { core::slice::from_raw_parts(current_address as *const u8, remaining_length as usize) };
         if accumulation_slice.is_empty() {

--- a/services/utils/src/host_functions.rs
+++ b/services/utils/src/host_functions.rs
@@ -84,6 +84,9 @@ extern "C" {
     #[polkavm_import(index = 26)]
     pub fn expunge(n: u64) -> u64;
 
+    #[polkavm_import(index = 27)]
+    pub fn provide(s: u64, o: u64, z: u64) -> u64;
+
     #[polkavm_import(index = 100)]
     pub fn log(level: u64, target: u64, target_len: u64, message: u64, message_len: u64) -> u64; //https://hackmd.io/@polkadot/jip1
 }


### PR DESCRIPTION
- [x] adds back usage of log_level 0/2 for corevm host func result checks which was lost
- [x] sets up stub for `provide` testing for 3/4 cases from 0.6.5
- [ ] address new r_g element of operand element 

See https://github.com/colorfulnotion/jam/pull/490 for matching 0.6.5

